### PR TITLE
Fix build (Hodl) on OSX (with GNU Gcc 6.x/Yasm)

### DIFF
--- a/algo/hodl/hodl-endian.h
+++ b/algo/hodl/hodl-endian.h
@@ -1,6 +1,8 @@
 #ifndef HODL_BYTESWAP_H
 #define HODL_BYTESWAP_H 1
 
+#include <stdint.h>
+
 #define __bswap_constant_16(x) \
      ((unsigned short int) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))
 

--- a/algo/hodl/hodl-endian.h
+++ b/algo/hodl/hodl-endian.h
@@ -1,7 +1,9 @@
 #ifndef HODL_BYTESWAP_H
 #define HODL_BYTESWAP_H 1
 
+#ifdef __APPLE__
 #include <stdint.h>
+#endif
 
 #define __bswap_constant_16(x) \
      ((unsigned short int) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))

--- a/algo/hodl/hodl-endian.h
+++ b/algo/hodl/hodl-endian.h
@@ -1,7 +1,7 @@
 #ifndef HODL_BYTESWAP_H
 #define HODL_BYTESWAP_H 1
 
-#ifdef __APPLE__
+#if ((defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)))
 #include <stdint.h>
 #endif
 

--- a/algo/hodl/hodl-gate.c
+++ b/algo/hodl/hodl-gate.c
@@ -12,9 +12,9 @@
 
 static struct work hodl_work;
 
-//#if (defined(__APPLE__) && !_POSIX_BARRIERS)
+#ifdef __APPLE__
 #include "pthread-barrier.h"
-//#endif
+#endif
 
 pthread_barrier_t hodl_barrier;
 

--- a/algo/hodl/hodl-gate.c
+++ b/algo/hodl/hodl-gate.c
@@ -12,6 +12,10 @@
 
 static struct work hodl_work;
 
+//#if (defined(__APPLE__) && !_POSIX_BARRIERS)
+#include "pthread-barrier.h"
+//#endif
+
 pthread_barrier_t hodl_barrier;
 
 // All references to this buffer are local to this file, so no args

--- a/algo/hodl/hodl_arith_uint256.cpp
+++ b/algo/hodl/hodl_arith_uint256.cpp
@@ -3,6 +3,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if ((defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)))
+#include "hodl-endian.h"
+#endif
+
 #include "hodl_arith_uint256.h"
 #include "hodl_uint256.h"
 #include "utilstrencodings.h"

--- a/algo/hodl/pthread-barrier.h
+++ b/algo/hodl/pthread-barrier.h
@@ -1,0 +1,68 @@
+#ifdef __APPLE__
+
+#ifndef PTHREAD_BARRIER_H_
+#define PTHREAD_BARRIER_H_
+
+#include <pthread.h>
+#include <errno.h>
+
+typedef int pthread_barrierattr_t;
+typedef struct
+{
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int count;
+    int tripCount;
+} pthread_barrier_t;
+
+
+int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count)
+{
+    if(count == 0)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+    if(pthread_mutex_init(&barrier->mutex, 0) < 0)
+    {
+        return -1;
+    }
+    if(pthread_cond_init(&barrier->cond, 0) < 0)
+    {
+        pthread_mutex_destroy(&barrier->mutex);
+        return -1;
+    }
+    barrier->tripCount = count;
+    barrier->count = 0;
+
+    return 0;
+}
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+    pthread_cond_destroy(&barrier->cond);
+    pthread_mutex_destroy(&barrier->mutex);
+    return 0;
+}
+
+int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+    pthread_mutex_lock(&barrier->mutex);
+    ++(barrier->count);
+    if(barrier->count >= barrier->tripCount)
+    {
+        barrier->count = 0;
+        pthread_cond_broadcast(&barrier->cond);
+        pthread_mutex_unlock(&barrier->mutex);
+        return 1;
+    }
+    else
+    {
+        pthread_cond_wait(&barrier->cond, &(barrier->mutex));
+        pthread_mutex_unlock(&barrier->mutex);
+        return 0;
+    }
+}
+
+#endif // PTHREAD_BARRIER_H_
+#endif // __APPLE__

--- a/algo/hodl/serialize.h
+++ b/algo/hodl/serialize.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_SERIALIZE_H
 #define BITCOIN_SERIALIZE_H
 
-#if ((defined(_WIN64) || defined(__WINDOWS__)))
+#if ((defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)))
 #include "hodl-endian.h"
 #endif
 

--- a/algo/hodl/sha256.cpp
+++ b/algo/hodl/sha256.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if ((defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)))
+#include "hodl-endian.h"
+#endif
+
 #include "sha256.h"
 #include "common.h"
 #include <string.h>

--- a/algo/hodl/sha512.cpp
+++ b/algo/hodl/sha512.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if ((defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)))
+#include "hodl-endian.h"
+#endif
+
 #include "sha512.h"
 #include "common.h"
 #include <string.h>

--- a/algo/hodl/sha512_avx.c
+++ b/algo/hodl/sha512_avx.c
@@ -8,7 +8,7 @@
 #include "smmintrin.h"
 
 #include "sha512-avx.h"
-#if ((defined(_WIN64) || defined(__WINDOWS__)))
+#if ((defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)))
 #include "hodl-endian.h"
 #endif
 

--- a/algo/hodl/sha512_avx2.c
+++ b/algo/hodl/sha512_avx2.c
@@ -8,7 +8,7 @@
 #include "immintrin.h"
 
 #include "sha512-avx.h"
-#if ((defined(_WIN64) || defined(__WINDOWS__)))
+#if ((defined(_WIN64) || defined(__WINDOWS__) || defined(__APPLE__)))
 #include "hodl-endian.h"
 #endif
 

--- a/api.c
+++ b/api.c
@@ -117,7 +117,7 @@ static void cpustatus(int thr_id)
 		cpu->thr_id = thr_id;
 		cpu->khashes = thr_hashrates[thr_id] / 1000.0; //todo: stats_get_speed(thr_id, 0.0) / 1000.0;
 
-		snprintf(buf, sizeof(buf), "CPU=%d;KHS=%.2f|", thr_id, cpu->khashes);
+		snprintf(buf, sizeof(buf), "{\"CPU\":\"%d\",\"KHS\":\"%.2f\"}", thr_id, cpu->khashes);
 
 		// append to buffer
 		strcat(buffer, buf);
@@ -147,15 +147,31 @@ static char *getsummary(char *params)
 	get_currentalgo(algo, sizeof(algo));
 
 	*buffer = '\0';
-	sprintf(buffer, "NAME=%s;VER=%s;API=%s;"
-		"ALGO=%s;CPUS=%d;KHS=%.2f;ACC=%d;REJ=%d;"
-		"ACCMN=%.3f;DIFF=%.6f;TEMP=%.1f;FAN=%d;FREQ=%d;"
-		"UPTIME=%.0f;TS=%u|",
+	sprintf(buffer, "{\"name\":\"%s\",\"ver\":\"%s\",\"api\":\"%s\","
+		"\"algo\":\"%s\",\"cpus\":\"%d\",\"KHS\":\"%.2f\",\"acc\":\"%d\",\"rej\":\"%d\","
+		"\"accmn\":\"%.3f\",\"diff\":\"%.6f\",\"temp\":\"%.1f\",\"fan\":\"%d\",\"freq\":\"%d\","
+		"\"uptime\":\"%.0f\",\"ts\":\"%u\"}",
 		PACKAGE_NAME, PACKAGE_VERSION, APIVERSION,
 		algo, opt_n_threads, (double)global_hashrate / 1000.0,
 		accepted_count, rejected_count, accps, net_diff > 0. ? net_diff : stratum_diff,
 		cpu.cpu_temp, cpu.cpu_fan, cpu.cpu_clock,
 		uptime, (uint32_t) ts);
+	return buffer;
+}
+
+/**
+* Returns miner global infos
+*/
+static char *gethashrate(char *params)
+{
+	double khashes = 0;
+        for (int i = 0; i < opt_n_threads; ++i) {
+                khashes = khashes + thr_hashrates[i];
+        }
+
+	*buffer = '\0';
+	sprintf(buffer, "{\"KHS\":\"%.2f\"}",
+		khashes / 1000.0);
 	return buffer;
 }
 
@@ -215,6 +231,7 @@ struct CMDS {
 } cmds[] = {
 	{ "summary", getsummary },
 	{ "threads", getthreads },
+	{ "hashrate", gethashrate },
 	/* remote functions */
 	{ "seturl", remote_seturl },
 	{ "quit",    remote_quit },


### PR DESCRIPTION
This fixes a few issues on OSX including:
- missing pthread barriers (add implementation for hodl)
- various macros defined in hodl-endian.h are also useful on OSX

There are limitations though. The native Clang (on Sierra at least) still cannot handle assembly for the Scrypt bits and GCC cannot process them either. While these issues may never be fixed, in the meantime I can compile using the following way using homebrew:

> brew install gcc yasm openssl curl gmp
> CC=gcc-6 CXX=g++-6 AS=yasm CFLAGS="-O3 -mtune=native -march=native -mavx -maes" CXXFLAGS="${CFLAGS}" LDFLAGS="-L/usr/local/opt/gmp/lib" ./configure --with-crypto=/usr/local/opt/openssl --with-curl=/usr/local/opt/curl --disable-assembly

Macs aren't of much interest for mining but this may prove useful to some anyhow. :)

NOTE: Using the native assembler also works but produces slower binaries. In Cryptonight the difference is around 2-3H/s per core on a i7-3615QM. AVX2 is not supported.
